### PR TITLE
Changed the logging to use the prometheus logger

### DIFF
--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -383,6 +383,6 @@ func main() {
 			</body>
 			</html>`))
 	})
-    log.Info("Listening on", *listenAddress)
+    log.Info("Listening on address:port => ", *listenAddress)
 	log.Fatal(http.ListenAndServe(*listenAddress, nil))
 }

--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -27,8 +27,8 @@ import (
 	"strconv"
 	"strings"
 
-    "github.com/prometheus/common/log"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 )
 
 var (
@@ -365,7 +365,7 @@ func main() {
 	)
 	flag.Parse()
 
-    log.Info("Starting unbound_exporter")
+	log.Info("Starting unbound_exporter")
 	exporter, err := NewUnboundExporter(*unboundHost, *unboundCa, *unboundCert, *unboundKey)
 	if err != nil {
 		panic(err)
@@ -383,6 +383,6 @@ func main() {
 			</body>
 			</html>`))
 	})
-    log.Info("Listening on address:port => ", *listenAddress)
+	log.Info("Listening on address:port => ", *listenAddress)
 	log.Fatal(http.ListenAndServe(*listenAddress, nil))
 }


### PR DESCRIPTION
Also removed some unused code

Produces output 
```
$ ./unbound_exporter -unbound.ca ca.pem -unbound.cert server.pem -unbound.key server.key 
INFO[0000] Starting unbound_exporter                     source="unbound_exporter.go:368"
INFO[0000] Listening on:9167                             source="unbound_exporter.go:386"
^C
```