### PR TITLE
Added new Unbound Metric for total TLS queries

### DIFF
--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -147,6 +147,12 @@ var (
 			nil,
 			"^num\\.query\\.tcp$"),
 		newUnboundMetric(
+			"query_tls_total",
+			"Total number of queries that were made using TCP TLS towards the Unbound server.",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.query\\.tls$"),
+		newUnboundMetric(
 			"query_types_total",
 			"Total number of queries with a given query type.",
 			prometheus.CounterValue,


### PR DESCRIPTION
Added one more metric for total TLS queries.
Tested on FreeBSD with unbound 1.8.1